### PR TITLE
Excluded V-93479 from the password history requirement for HML per ARS 5.0

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -351,7 +351,7 @@ inputs:
       - "V-93473" # IA-05(01) Requirement NA
       - "V-93475" # IA-05(01) Requirement NA
       - "V-93477" # IA-05(01) Requirement NA
-      - "V-93477" # IA-05(01) Requirement NA
+      - "V-93479" # IA-05(01) Requirement NA
       - "V-93481" # IA-05(02)
       - "V-93483" # IA-05(02)
       - "V-93485" # IA-05(02)

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,7 +5,7 @@ copyright:
 copyright_email:
 license: Apache-2.0
 summary: "CMS ARS 5.0 Overlay InSpec Validation Profile for Windows Server 2019 STIG"
-version: 1.3.0
+version: 1.3.1
 inspec_version: ">= 4.0"
 
 depends:
@@ -170,13 +170,7 @@ inputs:
     type: Numeric
     profile: microsoft-windows-server-2019-stig-baseline
     <% if ['High-HVA', 'Moderate-HVA', 'Low-HVA'].include? ENV['BASELINE'] %>
-    value: 24 # Same as the baseline parameter
-    <% elsif ENV['BASELINE'] == 'High' %>
-    value: 12
-    <% elsif ['Moderate', 'Low'].include? ENV['BASELINE'] %>
-    value: 6
-    <% elsif ENV['BASELINE'].nil? %>
-    value: 6
+    value: 24 # Max value to disallow password reuse
     <% end %>
 
   - name: maximum_idle_time # V-93509
@@ -229,6 +223,7 @@ inputs:
       - "V-93473" # IA-05(01) Requirement NA
       - "V-93475" # IA-05(01) Requirement NA
       - "V-93477" # IA-05(01) Requirement NA
+      - "V-93479" # IA-05(01) Requirement NA
     <% elsif ENV['BASELINE'] == 'Moderate-HVA' %>
     value: []
     <% elsif ENV['BASELINE'] == 'Moderate' || ENV['BASELINE'].nil? %> # Default
@@ -239,6 +234,7 @@ inputs:
       - "V-93473" # IA-05(01) Requirement NA
       - "V-93475" # IA-05(01) Requirement NA
       - "V-93477" # IA-05(01) Requirement NA
+      - "V-93479" # IA-05(01) Requirement NA
       - "V-93517" # SC-03
       - "V-93519" # SC-03
       - "V-93521" # SC-03
@@ -354,6 +350,7 @@ inputs:
       - "V-93471" # IA-05(01) Requirement NA
       - "V-93473" # IA-05(01) Requirement NA
       - "V-93475" # IA-05(01) Requirement NA
+      - "V-93477" # IA-05(01) Requirement NA
       - "V-93477" # IA-05(01) Requirement NA
       - "V-93481" # IA-05(02)
       - "V-93483" # IA-05(02)

--- a/inspec.yml
+++ b/inspec.yml
@@ -170,7 +170,7 @@ inputs:
     type: Numeric
     profile: microsoft-windows-server-2019-stig-baseline
     <% if ['High-HVA', 'Moderate-HVA', 'Low-HVA'].include? ENV['BASELINE'] %>
-    value: 24 # Max value to disallow password reuse
+    value: 24 # Max value to disallow password reuse (also same as the baseline parameter )
     <% end %>
 
   - name: maximum_idle_time # V-93509


### PR DESCRIPTION
…S 5.0

Signed-off-by: Dami Afolabi <dami.afolabi@icloud.com>